### PR TITLE
38 bootstrap lookup catalogues cities instruments genres

### DIFF
--- a/giggr/app/Models/City.php
+++ b/giggr/app/Models/City.php
@@ -3,15 +3,15 @@
 namespace App\Models;
 
 use Database\Factories\CityFactory;
-use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-#[Fillable(['name', 'slug', 'country', 'latitude', 'longitude'])]
 class City extends Model
 {
     /** @use HasFactory<CityFactory> */
     use HasFactory;
+
+    protected $fillable = ['name', 'slug', 'country', 'latitude', 'longitude'];
 
     protected function casts(): array
     {

--- a/giggr/app/Models/City.php
+++ b/giggr/app/Models/City.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\CityFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+#[Fillable(['name', 'slug', 'country', 'latitude', 'longitude'])]
+class City extends Model
+{
+    /** @use HasFactory<CityFactory> */
+    use HasFactory;
+
+    protected function casts(): array
+    {
+        return [
+            'latitude'  => 'float',
+            'longitude' => 'float',
+        ];
+    }
+}

--- a/giggr/app/Models/Genre.php
+++ b/giggr/app/Models/Genre.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Genre extends Model
+{
+    /** @use HasFactory<\Database\Factories\GenreFactory> */
+    use HasFactory;
+
+    protected $fillable = ['name', 'slug'];
+}

--- a/giggr/app/Models/Genre.php
+++ b/giggr/app/Models/Genre.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use Database\Factories\GenreFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Genre extends Model
 {
-    /** @use HasFactory<\Database\Factories\GenreFactory> */
+    /** @use HasFactory<GenreFactory> */
     use HasFactory;
 
     protected $fillable = ['name', 'slug'];

--- a/giggr/app/Models/Instrument.php
+++ b/giggr/app/Models/Instrument.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Instrument extends Model
+{
+    /** @use HasFactory<\Database\Factories\InstrumentFactory> */
+    use HasFactory;
+
+    protected $fillable = ['name', 'slug'];
+}

--- a/giggr/app/Models/Instrument.php
+++ b/giggr/app/Models/Instrument.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use Database\Factories\InstrumentFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Instrument extends Model
 {
-    /** @use HasFactory<\Database\Factories\InstrumentFactory> */
+    /** @use HasFactory<InstrumentFactory> */
     use HasFactory;
 
     protected $fillable = ['name', 'slug'];

--- a/giggr/app/Models/User.php
+++ b/giggr/app/Models/User.php
@@ -4,18 +4,18 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
-use Illuminate\Database\Eloquent\Attributes\Fillable;
-use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-#[Fillable(['name', 'email', 'password'])]
-#[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
+
+    protected $fillable = ['name', 'email', 'password'];
+
+    protected $hidden = ['password', 'remember_token'];
 
     /**
      * Get the attributes that should be cast.

--- a/giggr/database/factories/CityFactory.php
+++ b/giggr/database/factories/CityFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\City;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<City>
+ */
+class CityFactory extends Factory
+{
+    protected $model = City::class;
+
+    public function definition(): array
+    {
+        $name = fake()->unique()->city();
+
+        return [
+            'name'      => $name,
+            'slug'      => Str::slug($name),
+            'country'   => 'BE',
+            'latitude'  => fake()->randomFloat(5, 49.5, 51.5),
+            'longitude' => fake()->randomFloat(5, 2.5, 6.5),
+        ];
+    }
+}

--- a/giggr/database/factories/GenreFactory.php
+++ b/giggr/database/factories/GenreFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Genre;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Genre>
+ */
+class GenreFactory extends Factory
+{
+    protected $model = Genre::class;
+
+    public function definition(): array
+    {
+        $name = fake()->unique()->word();
+
+        return [
+            'name' => ucfirst($name),
+            'slug' => Str::slug($name),
+        ];
+    }
+}

--- a/giggr/database/factories/InstrumentFactory.php
+++ b/giggr/database/factories/InstrumentFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Instrument;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Instrument>
+ */
+class InstrumentFactory extends Factory
+{
+    protected $model = Instrument::class;
+
+    public function definition(): array
+    {
+        $name = fake()->unique()->word();
+
+        return [
+            'name' => ucfirst($name),
+            'slug' => Str::slug($name),
+        ];
+    }
+}

--- a/giggr/database/migrations/2026_04_30_094712_create_cities_table.php
+++ b/giggr/database/migrations/2026_04_30_094712_create_cities_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cities', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('country', 2)->default('BE');
+            $table->decimal('latitude',  total: 8, places: 5)->nullable();
+            $table->decimal('longitude', total: 8, places: 5)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cities');
+    }
+};

--- a/giggr/database/migrations/2026_04_30_100055_create_instruments_table.php
+++ b/giggr/database/migrations/2026_04_30_100055_create_instruments_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('instruments', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('instruments');
+    }
+};

--- a/giggr/database/migrations/2026_04_30_100308_create_genres_table.php
+++ b/giggr/database/migrations/2026_04_30_100308_create_genres_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('genres', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('genres');
+    }
+};

--- a/giggr/database/seeders/CitySeeder.php
+++ b/giggr/database/seeders/CitySeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\City;
+use Illuminate\Database\Seeder;
+
+class CitySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $cities = [
+            ['name' => 'Liège',      'slug' => 'liege',      'latitude' => 50.6326, 'longitude' => 5.5797],
+            ['name' => 'Bruxelles',  'slug' => 'bruxelles',  'latitude' => 50.8503, 'longitude' => 4.3517],
+            ['name' => 'Namur',      'slug' => 'namur',      'latitude' => 50.4674, 'longitude' => 4.8720],
+            ['name' => 'Charleroi',  'slug' => 'charleroi',  'latitude' => 50.4108, 'longitude' => 4.4446],
+            ['name' => 'Gand',       'slug' => 'gand',       'latitude' => 51.0543, 'longitude' => 3.7174],
+            ['name' => 'Mons',       'slug' => 'mons',       'latitude' => 50.4542, 'longitude' => 3.9523],
+            ['name' => 'Anvers',     'slug' => 'anvers',     'latitude' => 51.2194, 'longitude' => 4.4025],
+            ['name' => 'Louvain',    'slug' => 'louvain',    'latitude' => 50.8798, 'longitude' => 4.7005],
+            ['name' => 'Bruges',     'slug' => 'bruges',     'latitude' => 51.2093, 'longitude' => 3.2247],
+            ['name' => 'Tournai',    'slug' => 'tournai',    'latitude' => 50.6056, 'longitude' => 3.3886],
+        ];
+
+        foreach ($cities as $city) {
+            City::firstOrCreate(
+                ['slug' => $city['slug']],
+                [
+                    'name'      => $city['name'],
+                    'country'   => 'BE',
+                    'latitude'  => $city['latitude'],
+                    'longitude' => $city['longitude'],
+                ],
+            );
+        }
+    }
+}

--- a/giggr/database/seeders/CitySeeder.php
+++ b/giggr/database/seeders/CitySeeder.php
@@ -23,7 +23,7 @@ class CitySeeder extends Seeder
         ];
 
         foreach ($cities as $city) {
-            City::firstOrCreate(
+            City::updateOrCreate(
                 ['slug' => $city['slug']],
                 [
                     'name'      => $city['name'],

--- a/giggr/database/seeders/DatabaseSeeder.php
+++ b/giggr/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -10,16 +9,12 @@ class DatabaseSeeder extends Seeder
 {
     use WithoutModelEvents;
 
-    /**
-     * Seed the application's database.
-     */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            CitySeeder::class,
+            InstrumentSeeder::class,
+            GenreSeeder::class,
         ]);
     }
 }

--- a/giggr/database/seeders/GenreSeeder.php
+++ b/giggr/database/seeders/GenreSeeder.php
@@ -16,7 +16,7 @@ class GenreSeeder extends Seeder
         ];
 
         foreach ($genres as $name) {
-            Genre::firstOrCreate(
+            Genre::updateOrCreate(
                 ['slug' => Str::slug($name)],
                 ['name' => $name],
             );

--- a/giggr/database/seeders/GenreSeeder.php
+++ b/giggr/database/seeders/GenreSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Genre;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class GenreSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $genres = [
+            'Rock', 'Jazz', 'Pop', 'Folk', 'Metal', 'Classique',
+            'Electronic', 'Soul', 'Indie', 'Blues', 'World', 'Funk',
+        ];
+
+        foreach ($genres as $name) {
+            Genre::firstOrCreate(
+                ['slug' => Str::slug($name)],
+                ['name' => $name],
+            );
+        }
+    }
+}

--- a/giggr/database/seeders/InstrumentSeeder.php
+++ b/giggr/database/seeders/InstrumentSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Instrument;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class InstrumentSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $instruments = [
+            'Guitare', 'Basse', 'Batterie', 'Clavier', 'Violon',
+            'Chant', 'Saxophone', 'Trompette', 'Percussions',
+        ];
+
+        foreach ($instruments as $name) {
+            Instrument::firstOrCreate(
+                ['slug' => Str::slug($name)],
+                ['name' => $name],
+            );
+        }
+    }
+}

--- a/giggr/database/seeders/InstrumentSeeder.php
+++ b/giggr/database/seeders/InstrumentSeeder.php
@@ -16,7 +16,7 @@ class InstrumentSeeder extends Seeder
         ];
 
         foreach ($instruments as $name) {
-            Instrument::firstOrCreate(
+            Instrument::updateOrCreate(
                 ['slug' => Str::slug($name)],
                 ['name' => $name],
             );

--- a/giggr/tests/Feature/Models/CityTest.php
+++ b/giggr/tests/Feature/Models/CityTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Models\City;
+use Illuminate\Database\QueryException;
+
+it('can create a city with name, slug, country and coordinates', function () {
+    $city = City::create([
+        'name'      => 'Liège',
+        'slug'      => 'liege',
+        'country'   => 'BE',
+        'latitude'  => 50.6326,
+        'longitude' => 5.5797,
+    ]);
+
+    expect($city->fresh())
+        ->name->toBe('Liège')
+        ->slug->toBe('liege')
+        ->country->toBe('BE')
+        ->latitude->toEqual(50.6326)
+        ->longitude->toEqual(5.5797);
+});
+
+it('defaults country to BE when not provided', function () {
+    $city = City::create(['name' => 'Bruxelles', 'slug' => 'bruxelles']);
+
+    expect($city->fresh()->country)->toBe('BE');
+});
+
+it('allows null latitude and longitude', function () {
+    $city = City::create(['name' => 'Tournai', 'slug' => 'tournai']);
+
+    expect($city->fresh())
+        ->latitude->toBeNull()
+        ->longitude->toBeNull();
+});
+
+it('enforces a unique slug', function () {
+    City::create(['name' => 'Liège',  'slug' => 'liege']);
+
+    expect(fn () => City::create(['name' => 'Liege2', 'slug' => 'liege']))
+        ->toThrow(QueryException::class);
+});
+
+it('exposes a working factory', function () {
+    $city = City::factory()->create();
+
+    expect($city)->toBeInstanceOf(City::class)
+        ->and($city->slug)->not->toBeEmpty();
+});

--- a/giggr/tests/Feature/Models/GenreTest.php
+++ b/giggr/tests/Feature/Models/GenreTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Models\Genre;
+use Illuminate\Database\QueryException;
+
+it('can create a genre with name and slug', function () {
+    $genre = Genre::create(['name' => 'Rock', 'slug' => 'rock']);
+
+    expect($genre->fresh())
+        ->name->toBe('Rock')
+        ->slug->toBe('rock');
+});
+
+it('enforces a unique slug', function () {
+    Genre::create(['name' => 'Rock', 'slug' => 'rock']);
+
+    expect(fn () => Genre::create(['name' => 'Rock 2', 'slug' => 'rock']))
+        ->toThrow(QueryException::class);
+});
+
+it('exposes a working factory', function () {
+    $genre = Genre::factory()->create();
+
+    expect($genre)->toBeInstanceOf(Genre::class)
+        ->and($genre->slug)->not->toBeEmpty();
+});

--- a/giggr/tests/Feature/Models/InstrumentTest.php
+++ b/giggr/tests/Feature/Models/InstrumentTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Models\Instrument;
+use Illuminate\Database\QueryException;
+
+it('can create an instrument with name and slug', function () {
+    $instrument = Instrument::create(['name' => 'Guitare', 'slug' => 'guitare']);
+
+    expect($instrument->fresh())
+        ->name->toBe('Guitare')
+        ->slug->toBe('guitare');
+});
+
+it('enforces a unique slug', function () {
+    Instrument::create(['name' => 'Guitare', 'slug' => 'guitare']);
+
+    expect(fn () => Instrument::create(['name' => 'Guitare 2', 'slug' => 'guitare']))
+        ->toThrow(QueryException::class);
+});
+
+it('exposes a working factory', function () {
+    $instrument = Instrument::factory()->create();
+
+    expect($instrument)->toBeInstanceOf(Instrument::class)
+        ->and($instrument->slug)->not->toBeEmpty();
+});

--- a/giggr/tests/Feature/Seeders/CitySeederTest.php
+++ b/giggr/tests/Feature/Seeders/CitySeederTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Seeders;
+
+use App\Models\City;
+use Database\Seeders\CitySeeder;
+
+it('seeds 10 Belgian cities', function () {
+    $this->seed(CitySeeder::class);
+
+    expect(City::count())->toBe(10);
+});
+
+it('is idempotent — running twice does not duplicate rows', function () {
+    $this->seed(CitySeeder::class);
+    $this->seed(CitySeeder::class);
+
+    expect(City::count())->toBe(10);
+});
+
+it('seeds Liège with real coordinates', function () {
+    $this->seed(CitySeeder::class);
+
+    $liege = City::where('slug', 'liege')->first();
+
+    expect($liege)->not->toBeNull()
+        ->and($liege->name)->toBe('Liège')
+        ->and($liege->country)->toBe('BE')
+        ->and($liege->latitude)->toBeGreaterThan(50.0)
+        ->and($liege->longitude)->toBeGreaterThan(5.0);
+});

--- a/giggr/tests/Feature/Seeders/DatabaseSeederTest.php
+++ b/giggr/tests/Feature/Seeders/DatabaseSeederTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature\Seeders;
+
+use App\Models\City;
+use App\Models\Genre;
+use App\Models\Instrument;
+
+it('seeds all three lookup catalogues via DatabaseSeeder', function () {
+    $this->seed();
+
+    expect(City::count())->toBe(10)
+        ->and(Instrument::count())->toBe(9)
+        ->and(Genre::count())->toBe(12);
+});
+
+it('is idempotent end-to-end', function () {
+    $this->seed();
+    $this->seed();
+
+    expect(City::count())->toBe(10)
+        ->and(Instrument::count())->toBe(9)
+        ->and(Genre::count())->toBe(12);
+});

--- a/giggr/tests/Feature/Seeders/GenreSeederTest.php
+++ b/giggr/tests/Feature/Seeders/GenreSeederTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature\Seeders;
+
+use App\Models\Genre;
+use Database\Seeders\GenreSeeder;
+
+it('seeds 12 genres', function () {
+    $this->seed(GenreSeeder::class);
+
+    expect(Genre::count())->toBe(12);
+});
+
+it('is idempotent', function () {
+    $this->seed(GenreSeeder::class);
+    $this->seed(GenreSeeder::class);
+
+    expect(Genre::count())->toBe(12);
+});
+
+it('seeds Rock', function () {
+    $this->seed(GenreSeeder::class);
+
+    expect(Genre::where('slug', 'rock')->exists())->toBeTrue();
+});

--- a/giggr/tests/Feature/Seeders/InstrumentSeederTest.php
+++ b/giggr/tests/Feature/Seeders/InstrumentSeederTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature\Seeders;
+
+use App\Models\Instrument;
+use Database\Seeders\InstrumentSeeder;
+
+it('seeds 9 instruments', function () {
+    $this->seed(InstrumentSeeder::class);
+
+    expect(Instrument::count())->toBe(9);
+});
+
+it('is idempotent', function () {
+    $this->seed(InstrumentSeeder::class);
+    $this->seed(InstrumentSeeder::class);
+
+    expect(Instrument::count())->toBe(9);
+});
+
+it('seeds Guitare', function () {
+    $this->seed(InstrumentSeeder::class);
+
+    expect(Instrument::where('slug', 'guitare')->exists())->toBeTrue();
+});

--- a/giggr/tests/Feature/Smoke/DatabaseRefreshTest.php
+++ b/giggr/tests/Feature/Smoke/DatabaseRefreshTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature\Smoke;
+
+use Illuminate\Support\Facades\DB;
+
+it('starts every test with an empty users table', function () {
+    expect(DB::table('users')->count())->toBe(0);
+});
+
+it('does not leak data across tests', function () {
+    DB::table('users')->insert([
+        'name' => 'Leaky',
+        'email' => 'leak@example.com',
+        'password' => 'x',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    expect(DB::table('users')->count())->toBe(1);
+});
+
+it('confirms previous insert was rolled back', function () {
+    expect(DB::table('users')->count())->toBe(0);
+});

--- a/giggr/tests/Pest.php
+++ b/giggr/tests/Pest.php
@@ -15,7 +15,7 @@ use Tests\TestCase;
 */
 
 pest()->extend(TestCase::class)
- // ->use(RefreshDatabase::class)
+    ->use(RefreshDatabase::class)
     ->in('Feature');
 
 /*


### PR DESCRIPTION
**Adding models**

* Added new models: `City`, `Instrument`, and `Genre`, each with appropriate `$fillable` properties and, for `City`, attribute casting for latitude and longitude.
* Created database migrations to define `cities`, `instruments`, and `genres` tables with unique slugs and relevant fields. 
* Added factories for each model to support test data generation. 

**Seeding and Database Initialization**

* Implemented seeders for each catalogue, ensuring idempotent population of the tables with a predefined set of cities, instruments, and genres.
* Updated the main `DatabaseSeeder` to invoke all three new seeders.

**Testing**

* Added feature tests for each model, verifying creation, uniqueness constraints, default values, and factory functionality.
* Added feature tests for the seeders, ensuring correct data is seeded, idempotency, and data accuracy. 

**Other Model Improvements**

* Refactored the `User` model to use `$fillable` and `$hidden` properties instead of attributes, even if it is the new convention I don't like to use attributes for those properties.