### PR TITLE
Removed @persist directive

### DIFF
--- a/giggr/resources/views/layouts/app.blade.php
+++ b/giggr/resources/views/layouts/app.blade.php
@@ -21,9 +21,7 @@
         {{ $slot }}
     </main>
 
-    @persist('footer')
-        <x-footer />
-    @endpersist
+    <x-footer />
 
     <livewire:modal />
 


### PR DESCRIPTION
This directive was preventing the whole footer to reload, therefore the href in the langswitcher was still the one of the previous page