### PR TITLE
41 add polymorphic favorite model

### DIFF
--- a/giggr/app/Models/Favorite.php
+++ b/giggr/app/Models/Favorite.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\FavoriteFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Favorite extends Model
+{
+    /** @use HasFactory<FavoriteFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'favoritable_type',
+        'favoritable_id',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function favoritable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/giggr/app/Models/User.php
+++ b/giggr/app/Models/User.php
@@ -41,4 +41,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(Announcement::class);
     }
+
+    public function favorites(): HasMany
+    {
+        return $this->hasMany(Favorite::class);
+    }
 }

--- a/giggr/app/Providers/AppServiceProvider.php
+++ b/giggr/app/Providers/AppServiceProvider.php
@@ -2,11 +2,20 @@
 
 namespace App\Providers;
 
+use App\Models\Announcement;
+use App\Models\Profile;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
     public function register(): void {}
 
-    public function boot(): void {}
+    public function boot(): void
+    {
+        Relation::enforceMorphMap([
+            'profile' => Profile::class,
+            'announcement' => Announcement::class,
+        ]);
+    }
 }

--- a/giggr/database/factories/FavoriteFactory.php
+++ b/giggr/database/factories/FavoriteFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Announcement;
+use App\Models\Favorite;
+use App\Models\Profile;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Favorite>
+ */
+class FavoriteFactory extends Factory
+{
+    protected $model = Favorite::class;
+
+    public function definition(): array
+    {
+        $favoritable = fake()->boolean(50)
+            ? Profile::factory()->create()
+            : Announcement::factory()->create();
+
+        return [
+            'user_id' => User::factory(),
+            'favoritable_type' => $favoritable->getMorphClass(),
+            'favoritable_id' => $favoritable->id,
+        ];
+    }
+}

--- a/giggr/database/factories/FavoriteFactory.php
+++ b/giggr/database/factories/FavoriteFactory.php
@@ -17,14 +17,36 @@ class FavoriteFactory extends Factory
 
     public function definition(): array
     {
-        $favoritable = fake()->boolean(50)
-            ? Profile::factory()->create()
-            : Announcement::factory()->create();
-
         return [
             'user_id' => User::factory(),
-            'favoritable_type' => $favoritable->getMorphClass(),
-            'favoritable_id' => $favoritable->id,
+            'favoritable_type' => null,
+            'favoritable_id' => null,
         ];
+    }
+
+    public function configure(): static
+    {
+        return $this
+            ->afterMaking(function (Favorite $favorite): void {
+                $favoritable = fake()->boolean(50)
+                    ? Profile::factory()->make()
+                    : Announcement::factory()->make();
+
+                $favorite->favoritable_type = $favoritable->getMorphClass();
+                $favorite->favoritable_id = $favoritable->getKey();
+                $favorite->setRelation('favoritable', $favoritable);
+            })
+            ->afterCreating(function (Favorite $favorite): void {
+                $favoritable = fake()->boolean(50)
+                    ? Profile::factory()->create()
+                    : Announcement::factory()->create();
+
+                $favorite->forceFill([
+                    'favoritable_type' => $favoritable->getMorphClass(),
+                    'favoritable_id' => $favoritable->getKey(),
+                ])->save();
+
+                $favorite->setRelation('favoritable', $favoritable);
+            });
     }
 }

--- a/giggr/database/migrations/2026_04_30_181356_create_favorites_table.php
+++ b/giggr/database/migrations/2026_04_30_181356_create_favorites_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('favorites', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->morphs('favoritable');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'favoritable_type', 'favoritable_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('favorites');
+    }
+};

--- a/giggr/database/migrations/2026_04_30_181356_create_favorites_table.php
+++ b/giggr/database/migrations/2026_04_30_181356_create_favorites_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('favorites', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
-            $table->morphs('favoritable');
+            $table->nullableMorphs('favoritable');
             $table->timestamps();
 
             $table->unique(['user_id', 'favoritable_type', 'favoritable_id']);

--- a/giggr/tests/Feature/Models/FavoriteTest.php
+++ b/giggr/tests/Feature/Models/FavoriteTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use App\Models\Announcement;
+use App\Models\Favorite;
+use App\Models\Profile;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+
+it('belongs to a user', function () {
+    $user = User::factory()->create();
+    $profile = Profile::factory()->create();
+    $favorite = Favorite::create(['user_id' => $user->id, 'favoritable_type' => 'profile', 'favoritable_id' => $profile->id]);
+
+    expect($favorite->user)->toBeInstanceOf(User::class)
+        ->and($favorite->user->id)->toBe($user->id);
+});
+
+it('user has many favorites', function () {
+    $user = User::factory()->create();
+    $profile = Profile::factory()->create();
+    $announcement = Announcement::factory()->create();
+
+    Favorite::create(['user_id' => $user->id, 'favoritable_type' => 'profile', 'favoritable_id' => $profile->id]);
+    Favorite::create(['user_id' => $user->id, 'favoritable_type' => 'announcement', 'favoritable_id' => $announcement->id]);
+
+    expect($user->favorites)->toHaveCount(2);
+});
+
+it('morphs to a Profile', function () {
+    $user = User::factory()->create();
+    $profile = Profile::factory()->create();
+    $favorite = Favorite::create(['user_id' => $user->id, 'favoritable_type' => 'profile', 'favoritable_id' => $profile->id]);
+
+    expect($favorite->favoritable)->toBeInstanceOf(Profile::class)
+        ->and($favorite->favoritable->id)->toBe($profile->id);
+});
+
+it('morphs to an Announcement', function () {
+    $user = User::factory()->create();
+    $announcement = Announcement::factory()->create();
+    $favorite = Favorite::create(['user_id' => $user->id, 'favoritable_type' => 'announcement', 'favoritable_id' => $announcement->id]);
+
+    expect($favorite->favoritable)->toBeInstanceOf(Announcement::class)
+        ->and($favorite->favoritable->id)->toBe($announcement->id);
+});
+
+it('morph map stores profile string instead of class name', function () {
+    $user = User::factory()->create();
+    $profile = Profile::factory()->create();
+    $favorite = Favorite::create(['user_id' => $user->id, 'favoritable_type' => 'profile', 'favoritable_id' => $profile->id]);
+
+    expect($favorite->fresh()->favoritable_type)->toBe('profile');
+});
+
+it('morph map stores announcement string instead of class name', function () {
+    $user = User::factory()->create();
+    $announcement = Announcement::factory()->create();
+    $favorite = Favorite::create(['user_id' => $user->id, 'favoritable_type' => 'announcement', 'favoritable_id' => $announcement->id]);
+
+    expect($favorite->fresh()->favoritable_type)->toBe('announcement');
+});
+
+it('enforces composite unique constraint on user + favoritable', function () {
+    $user = User::factory()->create();
+    $profile = Profile::factory()->create();
+
+    Favorite::create(['user_id' => $user->id, 'favoritable_type' => 'profile', 'favoritable_id' => $profile->id]);
+
+    expect(fn () => Favorite::create(['user_id' => $user->id, 'favoritable_type' => 'profile', 'favoritable_id' => $profile->id]))
+        ->toThrow(QueryException::class);
+});
+
+it('exposes a working factory', function () {
+    $favorite = Favorite::factory()->create();
+
+    expect($favorite)->toBeInstanceOf(Favorite::class)
+        ->and($favorite->user_id)->not->toBeNull()
+        ->and($favorite->favoritable)->not->toBeNull();
+});


### PR DESCRIPTION
This pull request introduces a polymorphic "favorites" feature, allowing users to favorite both profiles and announcements. It includes the creation of a new `Favorite` model, its migration, factory, and comprehensive tests. The morph map is enforced for clean polymorphic relations, and the `User` model is updated to support retrieving a user's favorites.

**Favorites feature implementation:**

* Added a new `Favorite` model with polymorphic relations to allow users to favorite either a `Profile` or an `Announcement`. (`giggr/app/Models/Favorite.php`)
* Created a migration for the `favorites` table, including a composite unique constraint to ensure a user can't favorite the same item more than once. (`giggr/database/migrations/2026_04_30_181356_create_favorites_table.php`)
* Added a factory for the `Favorite` model to support test and seed data creation. (`giggr/database/factories/FavoriteFactory.php`)

**Model and relationship updates:**

* Updated the `User` model to define a `favorites()` relationship, enabling retrieval of all favorites for a user. (`giggr/app/Models/User.php`)
* Enforced a morph map in the `AppServiceProvider` so that the polymorphic type stores short strings (`profile`, `announcement`) instead of full class names. (`giggr/app/Providers/AppServiceProvider.php`)

**Testing:**

* Added comprehensive feature tests for the `Favorite` model, including relationship checks, morph map enforcement, unique constraint validation, and factory functionality. (`giggr/tests/Feature/Models/FavoriteTest.php`)