### PR TITLE
54 transform the musician slider into a livewire component

### DIFF
--- a/giggr/resources/js/components/musicians-slider.js
+++ b/giggr/resources/js/components/musicians-slider.js
@@ -3,16 +3,16 @@ document.addEventListener('alpine:init', () => {
         current:   0,
         count,
         pageCount: count,
-        _ro:       null,
+        _resizeObserver:       null,
 
         init() {
             this._sync();
-            this._ro = new ResizeObserver(() => this._sync());
-            this._ro.observe(this.$refs.track);
+            this._resizeObserver = new ResizeObserver(() => this._sync());
+            this._resizeObserver.observe(this.$refs.track);
         },
 
         destroy() {
-            this._ro?.disconnect();
+            this._resizeObserver?.disconnect();
         },
 
         _visible() {

--- a/giggr/resources/js/components/musicians-slider.js
+++ b/giggr/resources/js/components/musicians-slider.js
@@ -1,78 +1,50 @@
-const SMOOTH_MS = 350; // matches CSS smooth-scroll settle time
-const CLONE_MS  = 200; // debounce before teleporting out of clone zone
-
 document.addEventListener('alpine:init', () => {
-    window.Alpine.data('musiciansSlider', (real, clones) => ({
-        current: 0,
-        real,
-        clones,
-        teleporting: false,
-        _timer: null,
-        _items: null,
+    window.Alpine.data('musiciansSlider', (count) => ({
+        current:   0,
+        count,
+        pageCount: count,
+        _ro:       null,
 
         init() {
-            const track  = this.$refs.track;
-            this._items  = Array.from(track.children);
-            const first  = track.children[this.clones];
-            track.scrollLeft = first.offsetLeft - (track.offsetWidth - first.offsetWidth) / 2;
+            this._sync();
+            this._ro = new ResizeObserver(() => this._sync());
+            this._ro.observe(this.$refs.track);
         },
 
-        domIdx(r)       { return r + this.clones; },
-        isClone(domIdx) { return domIdx < this.clones || domIdx >= this.clones + this.real; },
+        destroy() {
+            this._ro?.disconnect();
+        },
 
-        centerLeft(idx) {
+        _visible() {
             const track = this.$refs.track;
-            const item  = track.children[idx];
-            return item.offsetLeft - (track.offsetWidth - item.offsetWidth) / 2;
+            if (!track.children.length) return 1;
+            const gap = parseFloat(getComputedStyle(track).columnGap) || 24;
+            return Math.max(1, Math.round((track.offsetWidth + gap) / (track.children[0].offsetWidth + gap)));
         },
 
-        go(idx, smooth = true) {
-            const track = this.$refs.track;
-            const left  = this.centerLeft(idx);
-            if (smooth) {
-                track.scrollTo({ left, behavior: 'smooth' });
-            } else {
-                this.teleporting = true;
-                track.style.scrollSnapType = 'none';
-                track.classList.remove('scroll-smooth');
-                track.scrollLeft = left;
-                void track.getBoundingClientRect(); // force reflow so scroll-snap re-enables from the new position
-                requestAnimationFrame(() => {
-                    track.style.scrollSnapType = '';
-                    track.classList.add('scroll-smooth');
-                    this.teleporting = false;
-                });
-            }
+        _sync() {
+            this.pageCount = Math.max(1, this.count - this._visible() + 1);
+            if (this.current >= this.pageCount) this.current = this.pageCount - 1;
         },
 
-        navigate(dir) {
-            const idx = this.domIdx(this.current) + dir;
-            this.go(idx);
-            this.current = (this.current + dir + this.real) % this.real;
-            if (this.isClone(idx)) {
-                setTimeout(() => this.go(this.domIdx(this.current), false), SMOOTH_MS);
-            }
+        go(idx) {
+            this.current = Math.max(0, Math.min(idx, this.pageCount - 1));
+            const item = this.$refs.track.children[this.current];
+            this.$refs.track.scrollTo({ left: item.offsetLeft, behavior: 'smooth' });
         },
 
-        next()      { this.navigate(1); },
-        prev()      { this.navigate(-1); },
-        goToReal(r) { this.current = r; this.go(this.domIdx(r)); },
+        prev() { this.go((this.current - 1 + this.pageCount) % this.pageCount); },
+        next() { this.go((this.current + 1) % this.pageCount); },
+        goTo(i) { this.go(i); },
 
         onScroll() {
-            if (this.teleporting) return;
-            const track      = this.$refs.track;
-            const viewCenter = track.scrollLeft + track.offsetWidth / 2;
+            const track = this.$refs.track;
             let closest = 0, minDist = Infinity;
-            this._items.forEach((item, i) => {
-                const d = Math.abs(item.offsetLeft + item.offsetWidth / 2 - viewCenter);
+            Array.from(track.children).forEach((item, i) => {
+                const d = Math.abs(item.offsetLeft - track.scrollLeft);
                 if (d < minDist) { minDist = d; closest = i; }
             });
-            this.current = ((closest - this.clones) % this.real + this.real) % this.real;
-
-            clearTimeout(this._timer);
-            if (this.isClone(closest)) {
-                this._timer = setTimeout(() => this.go(this.domIdx(this.current), false), CLONE_MS);
-            }
+            this.current = Math.min(closest, this.pageCount - 1);
         },
     }));
 });

--- a/giggr/resources/views/components/parts/home/⚡musician-slider.blade.php
+++ b/giggr/resources/views/components/parts/home/⚡musician-slider.blade.php
@@ -1,13 +1,23 @@
-@php
-$profiles = \App\Models\Profile::with(['user', 'city', 'instruments', 'genres'])
-    ->inRandomOrder()
-    ->limit(7)
-    ->get();
+<?php
 
-$cloneCount  = 3;
-$prepended   = $profiles->slice(-$cloneCount);
-$appended    = $profiles->slice(0, $cloneCount);
-$cardClass   = 'snap-center shrink-0 flex flex-col min-w-[250px] w-[85%] sm:w-[calc(50%-12px)] md:w-[calc(33.333%-16px)]';
+use App\Models\Profile;
+use Livewire\Component;
+
+new class extends Component {
+    public $profiles;
+
+    public function mount(): void
+    {
+        $this->profiles = Profile::with(['user', 'city', 'instruments', 'genres'])
+            ->inRandomOrder()
+            ->limit(7)
+            ->get();
+    }
+};
+?>
+
+@php
+    $cardClass = 'snap-start shrink-0 flex flex-col min-w-[250px] w-[85%] sm:w-[calc(50%-12px)] md:w-[calc(33.333%-16px)]';
 @endphp
 
 <section class="py-16 md:py-20 bg-pastel-salmon">
@@ -20,7 +30,7 @@ $cardClass   = 'snap-center shrink-0 flex flex-col min-w-[250px] w-[85%] sm:w-[c
 
         <div
             class="relative"
-            x-data="musiciansSlider({{ count($profiles) }}, {{ $cloneCount }})"
+            x-data="musiciansSlider({{ $profiles->count() }})"
         >
             <button
                 @click="prev()"
@@ -32,35 +42,18 @@ $cardClass   = 'snap-center shrink-0 flex flex-col min-w-[250px] w-[85%] sm:w-[c
                 </svg>
             </button>
 
-            {{-- Track --}}
             <div
                 x-ref="track"
                 @scroll.passive="onScroll()"
                 class="flex gap-6 overflow-x-auto snap-x snap-mandatory scroll-smooth scrollbar-none overscroll-x-contain pb-2"
             >
-                {{-- Clones gauche (dernières 3 cards) --}}
-                @foreach ($prepended as $profile)
-                    <div class="{{ $cardClass }}" aria-hidden="true">
-                        <x-musician-card :profile="$profile" />
-                    </div>
-                @endforeach
-
-                {{-- Cards réelles --}}
                 @foreach ($profiles as $profile)
                     <div class="{{ $cardClass }}">
                         <x-musician-card :profile="$profile" />
                     </div>
                 @endforeach
-
-                {{-- Clones droite (premières 3 cards) --}}
-                @foreach ($appended as $profile)
-                    <div class="{{ $cardClass }}" aria-hidden="true">
-                        <x-musician-card :profile="$profile" />
-                    </div>
-                @endforeach
             </div>
 
-            {{-- Flèche droite --}}
             <button
                 @click="next()"
                 class="hidden md:flex absolute -right-5 top-[calc(50%-2rem)] -translate-y-1/2 z-10 w-11 h-11 items-center justify-center rounded-full bg-bg border border-dark/15 shadow-sm text-dark hover:bg-dark hover:text-bg transition-colors duration-200 cursor-pointer"
@@ -71,11 +64,10 @@ $cardClass   = 'snap-center shrink-0 flex flex-col min-w-[250px] w-[85%] sm:w-[c
                 </svg>
             </button>
 
-            {{-- Dots --}}
             <div class="flex justify-center items-center gap-2 mt-8" role="tablist" aria-label="{{ __('home.carousel_aria') }}">
-                <template x-for="i in real" :key="i">
+                <template x-for="i in pageCount" :key="i">
                     <button
-                        @click="goToReal(i - 1)"
+                        @click="goTo(i - 1)"
                         :aria-label="`{{ __('home.carousel_goto') }}${i}`"
                         :aria-selected="current === i - 1"
                         class="h-2 rounded-full transition-all duration-300 cursor-pointer motion-reduce:transition-none"

--- a/giggr/resources/views/pages/home/⚡index.blade.php
+++ b/giggr/resources/views/pages/home/⚡index.blade.php
@@ -39,6 +39,6 @@ new #[Layout('layouts.app')] #[Title('Accueil')] class extends Component
         bg="bg-pastel-blue"
     />
     
-    <x-parts.home.musician-slider />
+    <livewire:parts.home.musician-slider />
 
 </div>

--- a/giggr/tests/Feature/Livewire/Home/MusicianSliderTest.php
+++ b/giggr/tests/Feature/Livewire/Home/MusicianSliderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Profile;
+use Database\Seeders\CitySeeder;
+use Database\Seeders\GenreSeeder;
+use Database\Seeders\InstrumentSeeder;
+use Livewire\Livewire;
+
+it('musician slider renders without error', function () {
+    $this->seed([CitySeeder::class, InstrumentSeeder::class, GenreSeeder::class]);
+    Profile::factory()->count(3)->create();
+
+    Livewire::test('parts.home.musician-slider')->assertOk();
+});
+
+it('musician slider exposes profiles collection', function () {
+    $this->seed([CitySeeder::class, InstrumentSeeder::class, GenreSeeder::class]);
+    Profile::factory()->count(3)->create();
+
+    Livewire::test('parts.home.musician-slider')
+        ->assertSet('profiles', fn ($profiles) => $profiles->count() === 3);
+});
+
+it('musician slider caps profiles at 7', function () {
+    $this->seed([CitySeeder::class, InstrumentSeeder::class, GenreSeeder::class]);
+    Profile::factory()->count(10)->create();
+
+    Livewire::test('parts.home.musician-slider')
+        ->assertSet('profiles', fn ($profiles) => $profiles->count() === 7);
+});


### PR DESCRIPTION
This pull request refactors the musician slider on the homepage to use a Livewire component instead of a Blade component, simplifies the slider logic, and removes the previous infinite-looping carousel with clones. The JavaScript controlling the slider is also rewritten for clarity and maintainability. Additionally, feature tests are added to ensure correct behavior of the new Livewire component.

**Migration to Livewire and Blade Refactor:**

* The musician slider is now implemented as a Livewire component (`parts.home.musician-slider`), replacing the previous Blade component and enabling dynamic server-side data loading.
* The Blade view for the slider has been renamed and refactored to remove the logic for cloning cards and infinite looping, simplifying the markup and logic.

**JavaScript Slider Logic Simplification:**

* The `musiciansSlider` Alpine.js component is rewritten to remove support for infinite looping and clones, now using a simpler paging system that calculates visible items and manages navigation accordingly.
* The slider navigation dots and button logic are updated to match the new paging system, improving accessibility and maintainability.

**Testing:**

* Feature tests are added to verify that the Livewire musician slider renders correctly, exposes the expected profiles collection, and limits the number of profiles to 7.