### PR TITLE
schema, Media model and Profile::media() relation

### DIFF
--- a/giggr/app/Enums/MediaType.php
+++ b/giggr/app/Enums/MediaType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum MediaType: string
+{
+    case Image = 'image';
+    case Youtube = 'youtube';
+
+    public function label(): string
+    {
+        return 'enums.media_type.'.$this->value;
+    }
+}

--- a/giggr/app/Models/Media.php
+++ b/giggr/app/Models/Media.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\MediaType;
+use Database\Factories\MediaFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
+
+class Media extends Model
+{
+    /** @use HasFactory<MediaFactory> */
+    use HasFactory;
+
+    private const string YOUTUBE_EMBED_URL = 'https://www.youtube.com/embed/';
+
+    private const string YOUTUBE_THUMBNAIL_URL = 'https://i.ytimg.com/vi/%s/hqdefault.jpg';
+
+    protected $table = 'media';
+
+    protected $fillable = [
+        'profile_id',
+        'type',
+        'source',
+        'position',
+        'caption',
+        'width',
+        'height',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'type' => MediaType::class,
+            'position' => 'integer',
+            'width' => 'integer',
+            'height' => 'integer',
+        ];
+    }
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(Profile::class);
+    }
+
+    protected function displayUrl(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): string => match ($this->type) {
+                MediaType::Youtube => self::YOUTUBE_EMBED_URL.$this->source,
+                MediaType::Image => Storage::disk(config('media.disk', 'public'))
+                    ->url("media/medium/{$this->source}.webp"),
+            },
+        );
+    }
+
+    protected function youtubeThumbnailUrl(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): ?string => $this->type === MediaType::Youtube
+                ? sprintf(self::YOUTUBE_THUMBNAIL_URL, $this->source)
+                : null,
+        );
+    }
+}

--- a/giggr/app/Models/Profile.php
+++ b/giggr/app/Models/Profile.php
@@ -62,6 +62,11 @@ class Profile extends Model
         return $this->morphMany(Follow::class, 'followable');
     }
 
+    public function media(): HasMany
+    {
+        return $this->hasMany(Media::class)->orderBy('position');
+    }
+
     public function followed(): HasMany
     {
         return $this->hasMany(Follow::class, 'user_id', 'user_id')

--- a/giggr/app/Models/Profile.php
+++ b/giggr/app/Models/Profile.php
@@ -64,7 +64,9 @@ class Profile extends Model
 
     public function media(): HasMany
     {
-        return $this->hasMany(Media::class)->orderBy('position');
+        return $this->hasMany(Media::class)
+            ->orderBy('position')
+            ->orderBy('id');
     }
 
     public function followed(): HasMany

--- a/giggr/database/factories/MediaFactory.php
+++ b/giggr/database/factories/MediaFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\MediaType;
+use App\Models\Media;
+use App\Models\Profile;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Media>
+ */
+class MediaFactory extends Factory
+{
+    protected $model = Media::class;
+
+    public function definition(): array
+    {
+        return [
+            'profile_id' => Profile::factory(),
+            'type' => MediaType::Image,
+            'source' => 'gallery-photo-'.Str::random(8),
+            'position' => 0,
+            'caption' => null,
+            'width' => fake()->numberBetween(800, 2400),
+            'height' => fake()->numberBetween(600, 1800),
+        ];
+    }
+
+    public function image(): static
+    {
+        return $this->state(fn () => [
+            'type' => MediaType::Image,
+            'source' => 'gallery-photo-'.Str::random(8),
+            'width' => fake()->numberBetween(800, 2400),
+            'height' => fake()->numberBetween(600, 1800),
+        ]);
+    }
+
+    public function youtube(): static
+    {
+        return $this->state(fn () => [
+            'type' => MediaType::Youtube,
+            'source' => Str::random(11),
+            'width' => null,
+            'height' => null,
+        ]);
+    }
+}

--- a/giggr/database/migrations/2026_05_10_160056_create_media_table.php
+++ b/giggr/database/migrations/2026_05_10_160056_create_media_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->unsignedSmallInteger('height')->nullable();
             $table->timestamps();
 
-            $table->index(['profile_id', 'position']);
+            $table->unique(['profile_id', 'position']);
         });
     }
 

--- a/giggr/database/migrations/2026_05_10_160056_create_media_table.php
+++ b/giggr/database/migrations/2026_05_10_160056_create_media_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('media', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('profile_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->string('source');
+            $table->unsignedSmallInteger('position')->default(0);
+            $table->string('caption')->nullable();
+            $table->unsignedSmallInteger('width')->nullable();
+            $table->unsignedSmallInteger('height')->nullable();
+            $table->timestamps();
+
+            $table->index(['profile_id', 'position']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('media');
+    }
+};

--- a/giggr/lang/en/enums.php
+++ b/giggr/lang/en/enums.php
@@ -15,4 +15,8 @@ return [
         'open_to_collab' => 'Open to collaboration',
         'not_available' => 'Not available',
     ],
+    'media_type' => [
+        'image' => 'Photo',
+        'youtube' => 'YouTube video',
+    ],
 ];

--- a/giggr/lang/fr/enums.php
+++ b/giggr/lang/fr/enums.php
@@ -15,4 +15,8 @@ return [
         'open_to_collab' => 'Ouvert collaboration',
         'not_available' => 'Non disponible',
     ],
+    'media_type' => [
+        'image' => 'Photo',
+        'youtube' => 'Vidéo YouTube',
+    ],
 ];

--- a/giggr/tests/Feature/Models/MediaTest.php
+++ b/giggr/tests/Feature/Models/MediaTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Enums\MediaType;
+use App\Models\Media;
+use App\Models\Profile;
+use Illuminate\Database\QueryException;
+
+it('can create an image media with all fields', function () {
+    $profile = Profile::factory()->create();
+
+    $media = Media::create([
+        'profile_id' => $profile->id,
+        'type' => MediaType::Image,
+        'source' => 'profiles-photo-abc12345',
+        'position' => 0,
+        'caption' => 'Mon dernier concert',
+        'width' => 1920,
+        'height' => 1280,
+    ]);
+
+    expect($media->fresh())
+        ->profile_id->toBe($profile->id)
+        ->type->toBe(MediaType::Image)
+        ->source->toBe('profiles-photo-abc12345')
+        ->position->toBe(0)
+        ->caption->toBe('Mon dernier concert')
+        ->width->toBe(1920)
+        ->height->toBe(1280);
+});
+
+it('can create a youtube media without dimensions', function () {
+    $profile = Profile::factory()->create();
+
+    $media = Media::create([
+        'profile_id' => $profile->id,
+        'type' => MediaType::Youtube,
+        'source' => 'cj9kbTU9pKA',
+        'position' => 0,
+    ]);
+
+    expect($media->fresh())
+        ->type->toBe(MediaType::Youtube)
+        ->source->toBe('cj9kbTU9pKA')
+        ->width->toBeNull()
+        ->height->toBeNull()
+        ->caption->toBeNull();
+});
+
+it('casts type to the MediaType enum', function () {
+    $profile = Profile::factory()->create();
+    $media = Media::create([
+        'profile_id' => $profile->id,
+        'type' => 'youtube',
+        'source' => 'cj9kbTU9pKA',
+    ]);
+
+    expect($media->fresh()->type)->toBeInstanceOf(MediaType::class)
+        ->and($media->fresh()->type)->toBe(MediaType::Youtube);
+});
+
+it('belongs to a profile', function () {
+    $profile = Profile::factory()->create();
+    $media = Media::factory()->create(['profile_id' => $profile->id]);
+
+    expect($media->profile)->toBeInstanceOf(Profile::class)
+        ->and($media->profile->id)->toBe($profile->id);
+});
+
+it('cascades on profile delete', function () {
+    $profile = Profile::factory()->create();
+    Media::factory()->count(3)->create(['profile_id' => $profile->id]);
+
+    $profile->forceDelete();
+
+    expect(Media::count())->toBe(0);
+});
+
+it('exposes a working factory with image state', function () {
+    $media = Media::factory()->image()->create();
+
+    expect($media)->toBeInstanceOf(Media::class)
+        ->and($media->type)->toBe(MediaType::Image)
+        ->and($media->source)->not->toBeEmpty()
+        ->and($media->width)->toBeInt()
+        ->and($media->height)->toBeInt();
+});
+
+it('exposes a working factory with youtube state', function () {
+    $media = Media::factory()->youtube()->create();
+
+    expect($media)->toBeInstanceOf(Media::class)
+        ->and($media->type)->toBe(MediaType::Youtube)
+        ->and($media->source)->toMatch('/^[A-Za-z0-9_-]{11}$/')
+        ->and($media->width)->toBeNull()
+        ->and($media->height)->toBeNull();
+});
+
+it('Profile::media() returns medias ordered by position', function () {
+    $profile = Profile::factory()->create();
+
+    Media::factory()->create(['profile_id' => $profile->id, 'position' => 2]);
+    Media::factory()->create(['profile_id' => $profile->id, 'position' => 0]);
+    Media::factory()->create(['profile_id' => $profile->id, 'position' => 1]);
+
+    expect($profile->media->pluck('position')->all())->toBe([0, 1, 2]);
+});
+
+it('display_url accessor returns the youtube embed url for youtube type', function () {
+    $media = Media::factory()->youtube()->create(['source' => 'cj9kbTU9pKA']);
+
+    expect($media->display_url)->toBe('https://www.youtube.com/embed/cj9kbTU9pKA');
+});
+
+it('display_url accessor returns a Storage url for image type', function () {
+    $media = Media::factory()->image()->create(['source' => 'profiles-photo-abc12345']);
+
+    // For images we expose the medium variant by default in display_url
+    expect($media->display_url)->toContain('profiles-photo-abc12345');
+});
+
+it('youtube_thumbnail_url accessor returns the i.ytimg.com hqdefault url', function () {
+    $media = Media::factory()->youtube()->create(['source' => 'cj9kbTU9pKA']);
+
+    expect($media->youtube_thumbnail_url)->toBe('https://i.ytimg.com/vi/cj9kbTU9pKA/hqdefault.jpg');
+});
+
+it('youtube_thumbnail_url is null for image type', function () {
+    $media = Media::factory()->image()->create();
+
+    expect($media->youtube_thumbnail_url)->toBeNull();
+});
+
+it('profile_id is required (not null at the DB level)', function () {
+    expect(fn () => Media::create([
+        'type' => MediaType::Image,
+        'source' => 'whatever',
+    ]))->toThrow(QueryException::class);
+});

--- a/giggr/tests/Feature/Models/MediaTest.php
+++ b/giggr/tests/Feature/Models/MediaTest.php
@@ -70,7 +70,10 @@ it('belongs to a profile', function () {
 
 it('cascades on profile delete', function () {
     $profile = Profile::factory()->create();
-    Media::factory()->count(3)->create(['profile_id' => $profile->id]);
+    Media::factory()
+        ->count(3)
+        ->sequence(fn ($s) => ['position' => $s->index])
+        ->create(['profile_id' => $profile->id]);
 
     $profile->forceDelete();
 
@@ -114,10 +117,8 @@ it('display_url accessor returns the youtube embed url for youtube type', functi
 });
 
 it('display_url accessor returns a Storage url for image type', function () {
-    $media = Media::factory()->image()->create(['source' => 'profiles-photo-abc12345']);
-
-    // For images we expose the medium variant by default in display_url
-    expect($media->display_url)->toContain('profiles-photo-abc12345');
+    $media = Media::factory()->image()->create(['source' => 'gallery-photo-abc12345']);
+    expect($media->display_url)->toContain('gallery-photo-abc12345');
 });
 
 it('youtube_thumbnail_url accessor returns the i.ytimg.com hqdefault url', function () {
@@ -137,4 +138,24 @@ it('profile_id is required (not null at the DB level)', function () {
         'type' => MediaType::Image,
         'source' => 'whatever',
     ]))->toThrow(QueryException::class);
+});
+
+it('enforces unique (profile_id, position) at the DB level', function () {
+    $profile = Profile::factory()->create();
+    Media::factory()->create(['profile_id' => $profile->id, 'position' => 5]);
+
+    expect(fn () => Media::factory()->create([
+        'profile_id' => $profile->id,
+        'position' => 5,
+    ]))->toThrow(QueryException::class);
+});
+
+it('allows the same position across different profiles', function () {
+    $profile1 = Profile::factory()->create();
+    $profile2 = Profile::factory()->create();
+
+    Media::factory()->create(['profile_id' => $profile1->id, 'position' => 0]);
+    Media::factory()->create(['profile_id' => $profile2->id, 'position' => 0]);
+
+    expect(Media::count())->toBe(2);
 });


### PR DESCRIPTION
This pull request introduces a new media management feature for user profiles, allowing profiles to be associated with different types of media (images and YouTube videos). It includes the creation of the necessary model, database migration, enum, relationships, factories, localization, and tests to ensure correctness.