### PR TITLE
fix(broadcasting): make the contact-preference channel private

### DIFF
--- a/giggr/app/Events/ContactPreferenceUpdated.php
+++ b/giggr/app/Events/ContactPreferenceUpdated.php
@@ -2,8 +2,8 @@
 
 namespace App\Events;
 
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
@@ -17,11 +17,11 @@ class ContactPreferenceUpdated implements ShouldBroadcastNow
     ) {}
 
     /**
-     * @return array<int, Channel>
+     * @return array<int, PrivateChannel>
      */
     public function broadcastOn(): array
     {
-        return [new Channel('profile.'.$this->profileId)];
+        return [new PrivateChannel('profile.'.$this->profileId)];
     }
 
     public function broadcastAs(): string

--- a/giggr/resources/views/pages/announcement/⚡show.blade.php
+++ b/giggr/resources/views/pages/announcement/⚡show.blade.php
@@ -39,7 +39,7 @@ new #[Layout('layouts.app')] class extends Component
             ->get();
     }
 
-    #[On('echo:profile.{announcement.user.profile.id},.contact-preference.updated')]
+    #[On('echo-private:profile.{announcement.user.profile.id},.contact-preference.updated')]
     public function refreshContactState(): void
     {
         $this->announcement->user->unsetRelation('profile');

--- a/giggr/resources/views/pages/profile/⚡show.blade.php
+++ b/giggr/resources/views/pages/profile/⚡show.blade.php
@@ -195,7 +195,7 @@ class extends Component
         $this->reloadRelationCounts();
     }
 
-    #[On('echo:profile.{profile.id},.contact-preference.updated')]
+    #[On('echo-private:profile.{profile.id},.contact-preference.updated')]
     public function refreshContactState(): void
     {
         $this->profile->user->unsetRelation('profile');

--- a/giggr/routes/channels.php
+++ b/giggr/routes/channels.php
@@ -8,4 +8,9 @@ Broadcast::channel('App.Models.User.{id}', function (User $user, int $id) {
     return $user->id === $id;
 });
 
+// Carries no payload beyond the profile id and only signals a UI refresh of the
+// contact button. Profiles are visible to any authenticated member, so any
+// signed-in user may listen; guests (who never reach a profile page) cannot.
+Broadcast::channel('profile.{profileId}', fn (User $user) => true);
+
 Broadcast::channel('conversation.{conversationId}', ConversationChannel::class);

--- a/giggr/tests/Feature/Events/ContactPreferenceUpdatedTest.php
+++ b/giggr/tests/Feature/Events/ContactPreferenceUpdatedTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Events\ContactPreferenceUpdated;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+
+it('implements ShouldBroadcastNow for synchronous broadcasting', function () {
+    expect(new ContactPreferenceUpdated(1))->toBeInstanceOf(ShouldBroadcastNow::class);
+});
+
+it('broadcasts on a private profile channel so anonymous clients cannot subscribe', function () {
+    $channels = (new ContactPreferenceUpdated(42))->broadcastOn();
+
+    expect($channels)->toHaveCount(1)
+        ->and($channels[0])->toBeInstanceOf(PrivateChannel::class)
+        ->and($channels[0]->name)->toBe('private-profile.42');
+});
+
+it('uses a short broadcast event name', function () {
+    expect((new ContactPreferenceUpdated(1))->broadcastAs())->toBe('contact-preference.updated');
+});


### PR DESCRIPTION
The contact-preference.updated event was the only event broadcast on a public channel, so any anonymous client could subscribe to profile.{id} and learn, in real time, that a member had just changed their contact setting (an activity/timing leak, even though the new value is not in the payload).

- broadcast on a PrivateChannel instead of a public Channel
- authorize the profile.{id} channel for any authenticated user in channels.php (profiles are auth-gated, so this matches who can already view them; guests can no longer subscribe)
- switch the profile and announcement page listeners to echo-private

No getListeners() rework is needed: both pages are auth+verified gated, so every viewer is authenticated and authorized — no guest hits /broadcasting/auth. Adds an event test asserting the private channel.